### PR TITLE
emergency hotfix for roulette rng bug

### DIFF
--- a/src/methods/roulette.ts
+++ b/src/methods/roulette.ts
@@ -61,15 +61,19 @@ const isWinningSpin = (color: string): {won: boolean, spunColor: string} => {
 };
 
 const getSpinResult = (): string => {
-	const rollNum: number = Math.floor(Math.random() * 37); 
+	// produces random int 0 thru 37 inclusive (38 total distinct outcomes)
+	const rollNum: number = Math.floor(Math.random() * 38);
 
+	// 0 thru 1 inclusive (2 distinct outcomes)
 	if (rollNum <= 1) {
 		return "green";
 	}
+	// 2 thru 19 inclusive (18 distinct outcomes)
 	else if (rollNum >= 2 && rollNum <= 19) {
 		return "black";
 	}
-	else { // rollNum >= 20 && rollNum <= 38
+	// 20 thru 37 inclusive (18 distinct outcomes)
+	else {
 		return "red";
 	}
 };


### PR DESCRIPTION
Was just looking at this code and found a bug with the roulette spin RNG. Since `Math.random()` generates a random decimal between 0 inclusive and 1 exclusive, multiplying it by 37 and doing `Math.floor()` on that has been producing a random integer between 0 inclusive and 36 inclusive, which is only 37 distinct total outcomes instead of 38. Fixing it so we now correctly have 38 total outcomes like an actual roulette wheel.